### PR TITLE
Refactor the Imagine stuff out of the event listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,10 @@ You can [read more about custom validation providers in the book](http://book.ca
 ##Customisation
 Proffer uses an event listener to generate thumbnails. If you want to customise your thumbnail generation in any way 
 you can either create your own listener and listen for the `Proffer.beforeThumbs` and `Proffer.afterThumbs` methods, or
-just extend and overload the methods in the default listener located in `src/Event/ImageTransform.php`.
+just extend and overload the methods in the default listener located in `src/Event/ProfferListener.php`.
+
+The listener is separated from the thumbnail generation allowing you to hook to your own class which allows you to use
+your own image library if you don't want to use Imagine.
 
 The thumbnails are generated using the (http://imagine.readthedocs.org/en/latest/index.html)[Imagine library]. So you can
 use the documentation there to build your own thumbnail generating listeners.

--- a/src/Event/ProfferListener.php
+++ b/src/Event/ProfferListener.php
@@ -9,22 +9,10 @@ namespace Proffer\Event;
 
 use Cake\Event\Event;
 use Cake\Event\EventListenerInterface;
-use Imagine\Filter\Transformation;
-use Imagine\Gd\Imagine as Gd;
-use Imagine\Gmagick\Imagine as Gmagick;
-use Imagine\Image\Box;
 use Imagine\Image\ImageInterface;
-use Imagine\Image\Point;
-use Imagine\Imagick\Imagine as Imagick;
+use Proffer\Lib\ImageTransform;
 
 class ProfferListener implements EventListenerInterface {
-
-/**
- * Store our instance of Imagine
- *
- * @var ImagineInterface $__imagine
- */
-	private $__imagine;
 
 /**
  * Returns a list of events this object is implementing. When the class is registered
@@ -35,117 +23,37 @@ class ProfferListener implements EventListenerInterface {
  */
 	public function implementedEvents() {
 		return [
-			'Proffer.beforeThumbs' => 'makeThumbnails',
-			'Proffer.afterThumbs' => 'saveThumbs'
+			'Proffer.beforeThumbs' => 'beforeThumbs',
+			'Proffer.afterThumbs' => 'afterThumbs'
 		];
 	}
 
 /**
- * Get the specified Imagine engine class
+ * Event handler for the beforeThumbs event
  *
- * @return ImagineInterface
- */
-	protected function _getImagine() {
-		return $this->__imagine;
-	}
-
-/**
- * Set the Imagine engine class
- *
- * @param string $engine The name of the image engine to use
- * @return void
- */
-	protected function _setImagine($engine) {
-		switch ($engine) {
-			default:
-			case 'gd':
-				$this->__imagine = new Gd();
-				break;
-			case 'gmagick':
-				$this->__imagine = new Gmagick();
-				break;
-			case 'imagick':
-				$this->__imagine = new Imagick();
-				break;
-		}
-	}
-
-/**
- * Generate thumbnails
- *
- * @param Event $event The event instance
- * @param array $path The path array
- * @param array $dimensions Array of thumbnail dimensions
- * @param string $thumbnailMethod Which engine to use to make thumbnails
+ * @param Event $event The passed event
+ * @param array $path Array of path data
+ * @param array $dimensions Array of dimensions in pixels
+ * @param string $thumbnailMethod The engine to use to make thumbnails
  * @return ImageInterface
  */
-	public function makeThumbnails(Event $event, array $path, array $dimensions, $thumbnailMethod = 'gd') {
-		$this->_setImagine($thumbnailMethod);
-
-		$image = $this->_getImagine()->open($path['full']);
-
-		if (isset($thumbSize['crop']) && $thumbSize['crop'] === false) {
-			$image = $this->_thumbnailCropScale($image, $dimensions['w'], $dimensions['h']);
-		} else {
-			$image = $this->_thumbnailScale($image, $dimensions['w'], $dimensions['h']);
-		}
-
-		return $image;
+	public function beforeThumbs(Event $event, array $path, array $dimensions, $thumbnailMethod = 'gd') {
+		$transform = new ImageTransform();
+		return $transform->makeThumbnails($path, $dimensions, $thumbnailMethod);
 	}
 
 /**
- * Save thumbnail to the file system
+ * Event handler for the afterThumbs event
  *
- * @param Event $event The event
- * @param ImageInterface $image The ImageInterface instance from Imagine
- * @param array $path The path array
- * @param string $prefix The thumbnail size prefix
+ * @param Event $event The passed event
+ * @param ImageInterface $image An Imagine image instance
+ * @param array $path Array of path data
+ * @param string $prefix The thumbnail prefix
  * @return ImageInterface
  */
-	public function saveThumbs(Event $event, ImageInterface $image, $path, $prefix) {
-		$filePath = $path['parts']['root'] . DS . $path['parts']['table'] . DS . $path['parts']['seed'] . DS . $prefix . '_' . $path['parts']['name'];
-		$image->save($filePath);
-
-		return $image;
+	public function afterThumbs(Event $event, ImageInterface $image, array $path, $prefix) {
+		$transform = new ImageTransform();
+		return $transform->saveThumbs($image, $path, $prefix);
 	}
 
-/**
- * Scale an image to best fit a thumbnail size
- *
- * @param ImageInterface $image The ImageInterface instance from Imagine
- * @param int $width The width in pixels
- * @param int $height The height in pixels
- * @return ImageInterface
- */
-	protected function _thumbnailScale($image, $width, $height) {
-		$transformation = new Transformation();
-		$transformation->thumbnail(new Box($width, $height));
-		return $transformation->apply($image);
-	}
-
-/**
- * Create a thumbnail by scaling an image and cropping it to fit the exact dimensions
- *
- * @param ImageInterface $image The ImageInterface instance from Imagine
- * @param int $targetWidth The width in pixels
- * @param int $targetHeight The height in pixels
- * @return ImageInterface
- */
-	protected function _thumbnailCropScale($image, $targetWidth, $targetHeight) {
-		$target = new Box($targetWidth, $targetHeight);
-		$sourceSize = $image->getSize();
-
-		if ($sourceSize->getWidth() > $sourceSize->getHeight()) {
-			$width = $sourceSize->getWidth() * ($target->getHeight() / $sourceSize->getHeight());
-			$cropPoint = new Point((int)(max($width - $target->getWidth(), 0) / 2), 0);
-		} else {
-			$height = $sourceSize->getHeight() * ($target->getWidth() / $sourceSize->getWidth());
-			$cropPoint = new Point(0, (int)(max($height - $target->getHeight(), 0) / 2));
-		}
-
-		$box = new Box($targetWidth, $targetHeight);
-
-		return $image->thumbnail($box, ImageInterface::THUMBNAIL_OUTBOUND)
-			->crop($cropPoint, $target);
-	}
 }

--- a/src/Lib/ImageTransform.php
+++ b/src/Lib/ImageTransform.php
@@ -7,9 +7,127 @@
 
 namespace Proffer\Lib;
 
+use Imagine\Filter\Transformation;
+use Imagine\Gd\Imagine as Gd;
+use Imagine\Gmagick\Imagine as Gmagick;
+use Imagine\Image\Box;
+use Imagine\Image\ImageInterface;
+use Imagine\Image\Point;
+use Imagine\Imagick\Imagine as Imagick;
 
 class ImageTransform {
 
+/**
+ * Store our instance of Imagine
+ *
+ * @var ImagineInterface $__imagine
+ */
+	private $__imagine;
 
+/**
+ * Get the specified Imagine engine class
+ *
+ * @return ImagineInterface
+ */
+	protected function _getImagine() {
+		return $this->__imagine;
+	}
 
+/**
+ * Set the Imagine engine class
+ *
+ * @param string $engine The name of the image engine to use
+ * @return void
+ */
+	protected function _setImagine($engine) {
+		switch ($engine) {
+			default:
+			case 'gd':
+				$this->__imagine = new Gd();
+				break;
+			case 'gmagick':
+				$this->__imagine = new Gmagick();
+				break;
+			case 'imagick':
+				$this->__imagine = new Imagick();
+				break;
+		}
+	}
+
+/**
+ * Generate thumbnails
+ *
+ * @param array $path The path array
+ * @param array $dimensions Array of thumbnail dimensions
+ * @param string $thumbnailMethod Which engine to use to make thumbnails
+ * @return ImageInterface
+ */
+	public function makeThumbnails(array $path, array $dimensions, $thumbnailMethod = 'gd') {
+		$this->_setImagine($thumbnailMethod);
+
+		$image = $this->_getImagine()->open($path['full']);
+
+		if (isset($thumbSize['crop']) && $thumbSize['crop'] === false) {
+			$image = $this->_thumbnailCropScale($image, $dimensions['w'], $dimensions['h']);
+		} else {
+			$image = $this->_thumbnailScale($image, $dimensions['w'], $dimensions['h']);
+		}
+
+		return $image;
+	}
+
+/**
+ * Save thumbnail to the file system
+ *
+ * @param ImageInterface $image The ImageInterface instance from Imagine
+ * @param array $path The path array
+ * @param string $prefix The thumbnail size prefix
+ * @return ImageInterface
+ */
+	public function saveThumbs(ImageInterface $image, $path, $prefix) {
+		$filePath = $path['parts']['root'] . DS . $path['parts']['table'] . DS . $path['parts']['seed'] . DS . $prefix . '_' . $path['parts']['name'];
+		$image->save($filePath);
+
+		return $image;
+	}
+
+/**
+ * Scale an image to best fit a thumbnail size
+ *
+ * @param ImageInterface $image The ImageInterface instance from Imagine
+ * @param int $width The width in pixels
+ * @param int $height The height in pixels
+ * @return ImageInterface
+ */
+	protected function _thumbnailScale($image, $width, $height) {
+		$transformation = new Transformation();
+		$transformation->thumbnail(new Box($width, $height));
+		return $transformation->apply($image);
+	}
+
+/**
+ * Create a thumbnail by scaling an image and cropping it to fit the exact dimensions
+ *
+ * @param ImageInterface $image The ImageInterface instance from Imagine
+ * @param int $targetWidth The width in pixels
+ * @param int $targetHeight The height in pixels
+ * @return ImageInterface
+ */
+	protected function _thumbnailCropScale($image, $targetWidth, $targetHeight) {
+		$target = new Box($targetWidth, $targetHeight);
+		$sourceSize = $image->getSize();
+
+		if ($sourceSize->getWidth() > $sourceSize->getHeight()) {
+			$width = $sourceSize->getWidth() * ($target->getHeight() / $sourceSize->getHeight());
+			$cropPoint = new Point((int)(max($width - $target->getWidth(), 0) / 2), 0);
+		} else {
+			$height = $sourceSize->getHeight() * ($target->getWidth() / $sourceSize->getWidth());
+			$cropPoint = new Point(0, (int)(max($height - $target->getHeight(), 0) / 2));
+		}
+
+		$box = new Box($targetWidth, $targetHeight);
+
+		return $image->thumbnail($box, ImageInterface::THUMBNAIL_OUTBOUND)
+			->crop($cropPoint, $target);
+	}
 }

--- a/src/Model/Behavior/ProfferBehavior.php
+++ b/src/Model/Behavior/ProfferBehavior.php
@@ -97,13 +97,13 @@ class ProfferBehavior extends Behavior {
 	}
 
 /**
- * Generate the defined thumbnails
+ * Dispatch events to allow generation of thumbnails
  *
  * @param string $field The name of the upload field
- * @param string $path The path array
+ * @param array $path The path array
  * @return void
  */
-	protected function _makeThumbs($field, $path) {
+	protected function _makeThumbs($field, array $path) {
 		foreach ($this->config($field)['thumbnailSizes'] as $prefix => $dimensions) {
 
 			$eventParams = ['path' => $path, 'dimensions' => $dimensions, 'thumbnailMethod' => null];


### PR DESCRIPTION
To preserve the SOLID principles the event listener should know how to listen for events and not how to generate images.
