### PR TITLE
Replace beforeValidate with beforeMarshal

### DIFF
--- a/src/Model/Behavior/ProfferBehavior.php
+++ b/src/Model/Behavior/ProfferBehavior.php
@@ -34,23 +34,21 @@ class ProfferBehavior extends Behavior
     }
 
     /**
-     * beforeValidate method
+     * beforeMarshal event
      *
-     * @param Event $event The event
-     * @param Entity $entity The current entity
-     * @param ArrayObject $options Array of options
-     * @return true
+     * @param Event $event
+     * @param ArrayObject $data
+     * @param ArrayObject $options
      */
-    public function beforeValidate(Event $event, Entity $entity, ArrayObject $options)
+    public function beforeMarshal(Event $event, ArrayObject $data, ArrayObject $options)
     {
         foreach ($this->config() as $field => $settings) {
             if ($this->_table->validator()->isEmptyAllowed($field, false) &&
-                isset($entity->get($field)['error']) && $entity->get($field)['error'] === UPLOAD_ERR_NO_FILE) {
-                $entity->__unset($field);
+                isset($data[$field]['error']) && $data[$field]['error'] === UPLOAD_ERR_NO_FILE
+            ) {
+                unset($data[$field]);
             }
         }
-
-        return true;
     }
 
     /**

--- a/tests/TestCase/Model/Behavior/ProfferBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ProfferBehaviorTest.php
@@ -129,7 +129,7 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
      *
      * @return array
      */
-    public function beforeValidateProvider()
+    public function beforeMarshalProvider()
     {
         return [
             [
@@ -156,9 +156,9 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider beforeValidateProvider
+     * @dataProvider beforeMarshalProvider
      */
-    public function testBeforeValidate($entityData, $allowEmpty, $expected)
+    public function testBeforeMarshal(array $data, $allowEmpty, array $expected)
     {
         $table = $this->getMock('Cake\ORM\Table', ['alias']);
         $table->method('alias')
@@ -173,16 +173,16 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
             $table->validator()->allowEmpty('photo');
         }
 
-        $entity = new Entity($entityData);
+        $arrayObject = new ArrayObject($data);
 
-        $Proffer->beforeValidate(
+        $Proffer->beforeMarshal(
             $this->getMock('Cake\Event\Event', null, ['beforeValidate']),
-            $entity,
+            $arrayObject,
             new ArrayObject()
         );
-        $result = $entity->toArray();
+        $result = $arrayObject;
 
-        $this->assertEquals($expected, $result);
+        $this->assertEquals(new ArrayObject($expected), $result);
     }
 
     /**


### PR DESCRIPTION
So it seems that in RC1 the `beforeValidate() ` callback was removed, which meant that `allowEmpty()` image fields were not being properly stripped.