### PR TITLE
Resolves #28

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You will need to add a few things to your Table class.
 // Configure your upload field to use the file datatype
 protected function _initializeSchema(\Cake\Database\Schema\Table $table)
 {
-    $table->columnType('photo', 'file');
+    $table->columnType('photo', 'proffer.file');
     return $table;
 }
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can find it on Packagist [https://packagist.org/packages/davidyell/proffer](
 Add it to your `composer.json` in your require section `"davidyell/proffer": "dev-master"` and then run `composer update`.
 
 ### CakePHP
-Then you'll need to load the plugin in your `config/bootstrap.php` file. `Plugin::load('Proffer');`.
+Then you'll need to load the plugin in your `config/bootstrap.php` file. `Plugin::load('Proffer', ['bootstrap' => true);`.
 
 ### Database
 Next you need to add the fields to your table. You'll want to add your file upload field, this will store the name of the uploaded file such as `example.jpg` and you also need the dir field to store the directory in which the file has been stored. By default this is `dir`.

--- a/README.md
+++ b/README.md
@@ -35,13 +35,21 @@ Then you'll need to load the plugin in your `config/bootstrap.php` file. `Plugin
 Next you need to add the fields to your table. You'll want to add your file upload field, this will store the name of the uploaded file such as `example.jpg` and you also need the dir field to store the directory in which the file has been stored. By default this is `dir`.
 
 ##Configuration
-You will need to add the behaviour to your Table class.
+You will need to add a few things to your Table class.
 
 ```php
 <?php
+// Configure your upload field to use the file datatype
+protected function _initializeSchema(\Cake\Database\Schema\Table $table)
+{
+    $table->columnType('photo', 'file');
+    return $table;
+}
+
+// Add the behaviour and configure any options you want
 $this->addBehavior('Proffer.Proffer', [
 	'photo' => [	// The name of your upload field
-		'root' => WWW_DIR . 'files', // Customise the root upload folder here, or leave blank to use the default
+		'root' => WWW_DIR . 'files', // Customise the root upload folder here, or omit to use the default
 		'dir' => 'photo_dir',	// The name of the field to store the folder
 		'thumbnailSizes' => [
 			'square' => ['w' => 200, 'h' => 200],	// Define the size and prefix of your thumbnails

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -3,9 +3,8 @@
 /**
  * @category Proffer
  * @package bootstrap.php
- * 
+ *
  * @author David Yell <neon1024@gmail.com>
- * @when 03/03/15
  *
  */
 
@@ -13,4 +12,4 @@ namespace Proffer\config;
 
 use Cake\Database\Type;
 
-Type::map('file', 'Proffer\Database\Type\FileType');
+Type::map('proffer.file', 'Proffer\Database\Type\FileType');

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @category Proffer
+ * @package bootstrap.php
+ * 
+ * @author David Yell <neon1024@gmail.com>
+ * @when 03/03/15
+ *
+ */
+
+namespace Proffer\config;
+
+use Cake\Database\Type;
+
+Type::map('file', 'Proffer\Database\Type\FileType');

--- a/src/Database/Type/FileType.php
+++ b/src/Database/Type/FileType.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @category Proffer
+ * @package FileType.php
+ * 
+ * @author David Yell <neon1024@gmail.com>
+ * @when 03/03/15
+ *
+ */
+
+namespace Proffer\Database\Type;
+
+use Cake\Database\Driver;
+use Cake\Database\Type;
+use PDO;
+
+class FileType extends Type
+{
+    public function toDatabase($value, Driver $driver)
+    {
+        return $value;
+    }
+
+    public function toPHP($value, Driver $driver)
+    {
+        return $value;
+    }
+
+    public function toStatement($value, Driver $driver)
+    {
+        return PDO::PARAM_STR;
+    }
+
+}

--- a/src/Database/Type/FileType.php
+++ b/src/Database/Type/FileType.php
@@ -3,7 +3,7 @@
 /**
  * @category Proffer
  * @package FileType.php
- * 
+ *
  * @author David Yell <neon1024@gmail.com>
  * @when 03/03/15
  *
@@ -31,5 +31,4 @@ class FileType extends Type
     {
         return PDO::PARAM_STR;
     }
-
 }

--- a/src/Model/Behavior/ProfferBehavior.php
+++ b/src/Model/Behavior/ProfferBehavior.php
@@ -30,7 +30,7 @@ class ProfferBehavior extends Behavior
     public function initialize(array $config)
     {
         $listener = new ProfferListener();
-        $this->_table->eventManager()->attach($listener);
+        $this->_table->eventManager()->on($listener);
     }
 
     /**


### PR DESCRIPTION
Created a custom data type class to handle file uploads, when using a property which is present in the entity. The marshaller will cast entity fields to a matching database datatype, which meant that the upload array was being cast to a string.

This fix prevents the casting to string.