### PR TITLE
Allow filesystem uploads

### DIFF
--- a/src/Model/Behavior/ProfferBehavior.php
+++ b/src/Model/Behavior/ProfferBehavior.php
@@ -177,6 +177,7 @@ class ProfferBehavior extends Behavior
      *
      * @param string $file The tmp_name path to the uploaded file
      * @return bool
+     * @deprecated
      */
     protected function isUploadedFile($file)
     {
@@ -192,7 +193,7 @@ class ProfferBehavior extends Behavior
      */
     protected function moveUploadedFile($file, $destination)
     {
-        if ($this->isUploadedFile($file)) {
+        if ($this->is_uploaded_file($file)) {
             return move_uploaded_file($file, $destination);
         }
 

--- a/src/Model/Behavior/ProfferBehavior.php
+++ b/src/Model/Behavior/ProfferBehavior.php
@@ -66,9 +66,6 @@ class ProfferBehavior extends Behavior
         foreach ($this->config() as $field => $settings) {
             if ($entity->has($field) && is_array($entity->get($field)) &&
                 $entity->get($field)['error'] === UPLOAD_ERR_OK) {
-//                if (!$this->isUploadedFile($entity->get($field)['tmp_name'])) {
-//                    throw new Exception('File must be uploaded using HTTP post.');
-//                }
 
                 if (!$path) {
                     $path = new ProfferPath($this->_table, $entity, $field, $settings);
@@ -173,19 +170,8 @@ class ProfferBehavior extends Behavior
     }
 
     /**
-     * Wrapper method for is_uploaded_file so that we can test
-     *
-     * @param string $file The tmp_name path to the uploaded file
-     * @return bool
-     * @deprecated
-     */
-    protected function isUploadedFile($file)
-    {
-        return is_uploaded_file($file);
-    }
-
-    /**
-     * Wrapper method for move_uploaded_file so that we can test
+     * Wrapper method for move_uploaded_file
+     * This will check if the file has been uploaded or not before picking the correct method to move the file
      *
      * @param string $file Path to the uploaded file
      * @param string $destination The destination file name
@@ -193,7 +179,7 @@ class ProfferBehavior extends Behavior
      */
     protected function moveUploadedFile($file, $destination)
     {
-        if ($this->is_uploaded_file($file)) {
+        if (is_uploaded_file($file)) {
             return move_uploaded_file($file, $destination);
         }
 

--- a/src/Model/Behavior/ProfferBehavior.php
+++ b/src/Model/Behavior/ProfferBehavior.php
@@ -66,9 +66,9 @@ class ProfferBehavior extends Behavior
         foreach ($this->config() as $field => $settings) {
             if ($entity->has($field) && is_array($entity->get($field)) &&
                 $entity->get($field)['error'] === UPLOAD_ERR_OK) {
-                if (!$this->isUploadedFile($entity->get($field)['tmp_name'])) {
-                    throw new Exception('File must be uploaded using HTTP post.');
-                }
+//                if (!$this->isUploadedFile($entity->get($field)['tmp_name'])) {
+//                    throw new Exception('File must be uploaded using HTTP post.');
+//                }
 
                 if (!$path) {
                     $path = new ProfferPath($this->_table, $entity, $field, $settings);
@@ -192,6 +192,10 @@ class ProfferBehavior extends Behavior
      */
     protected function moveUploadedFile($file, $destination)
     {
-        return move_uploaded_file($file, $destination);
+        if ($this->isUploadedFile($file)) {
+            return move_uploaded_file($file, $destination);
+        }
+
+        return rename($file, $destination);
     }
 }

--- a/tests/TestCase/Model/Behavior/ProfferBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ProfferBehaviorTest.php
@@ -257,12 +257,8 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
 
         $Proffer = $this->getMockBuilder('Proffer\Model\Behavior\ProfferBehavior')
             ->setConstructorArgs([$table, $this->config])
-            ->setMethods(['isUploadedFile', 'moveUploadedFile'])
+            ->setMethods(['moveUploadedFile'])
             ->getMock();
-
-        $Proffer->expects($this->never())
-            ->method('isUploadedFile')
-            ->willReturn(true);
 
         $Proffer->expects($this->once())
             ->method('moveUploadedFile')
@@ -307,12 +303,8 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
 
         $Proffer = $this->getMockBuilder('Proffer\Model\Behavior\ProfferBehavior')
             ->setConstructorArgs([$table, $this->config])
-            ->setMethods(['isUploadedFile', 'moveUploadedFile'])
+            ->setMethods(['moveUploadedFile'])
             ->getMock();
-
-        $Proffer->expects($this->never())
-            ->method('isUploadedFile')
-            ->willReturn(false);
 
         $Proffer->expects($this->once())
             ->method('moveUploadedFile')
@@ -346,12 +338,8 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
 
         $Proffer = $this->getMockBuilder('Proffer\Model\Behavior\ProfferBehavior')
             ->setConstructorArgs([$table, $this->config])
-            ->setMethods(['isUploadedFile', 'moveUploadedFile'])
+            ->setMethods(['moveUploadedFile'])
             ->getMock();
-
-        $Proffer->expects($this->never())
-            ->method('isUploadedFile')
-            ->willReturn(true);
 
         $Proffer->expects($this->once())
             ->method('moveUploadedFile')

--- a/tests/TestCase/Model/Behavior/ProfferBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ProfferBehaviorTest.php
@@ -260,7 +260,7 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
             ->setMethods(['isUploadedFile', 'moveUploadedFile'])
             ->getMock();
 
-        $Proffer->expects($this->once())
+        $Proffer->expects($this->never())
             ->method('isUploadedFile')
             ->willReturn(true);
 
@@ -310,11 +310,11 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
             ->setMethods(['isUploadedFile', 'moveUploadedFile'])
             ->getMock();
 
-        $Proffer->expects($this->once())
+        $Proffer->expects($this->never())
             ->method('isUploadedFile')
             ->willReturn(false);
 
-        $Proffer->expects($this->never())
+        $Proffer->expects($this->once())
             ->method('moveUploadedFile')
             ->willReturn(false);
 
@@ -349,7 +349,7 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
             ->setMethods(['isUploadedFile', 'moveUploadedFile'])
             ->getMock();
 
-        $Proffer->expects($this->once())
+        $Proffer->expects($this->never())
             ->method('isUploadedFile')
             ->willReturn(true);
 


### PR DESCRIPTION
Refactored the check for uploads so that files can be uploaded from the local filesystem without them needing to be uploaded.

This means that a single upload can be persisted between form submissions without it failing because it's not uploaded.