### PR TITLE
change afterCreateImage to pass image paths at once

### DIFF
--- a/src/Model/Behavior/ProfferBehavior.php
+++ b/src/Model/Behavior/ProfferBehavior.php
@@ -89,9 +89,7 @@ class ProfferBehavior extends Behavior
                 $path->createPathFolder();
 
                 if ($this->moveUploadedFile($entity->get($field)['tmp_name'], $path->fullPath())) {
-                    $eventData = ['path' => $path, 'image' => $path->fullPath()];
-                    $event = new Event('Proffer.afterCreateImage', $entity, $eventData);
-                    $this->_table->eventManager()->dispatch($event);
+                    $imagePaths = [$path->fullPath()];
 
                     $entity->set($field, $path->getFilename());
                     $entity->set($settings['dir'], $path->getSeed());
@@ -106,14 +104,11 @@ class ProfferBehavior extends Behavior
                         }
 
                         $thumbnailPaths = $imageTransform->processThumbnails($settings);
-                        if (!empty($thumbnailPaths) && is_array($thumbnailPaths)) {
-                            foreach ($thumbnailPaths as $thumbnailPath) {
-                                $eventData = ['path' => $path, 'image' => $thumbnailPath];
-                                $event = new Event('Proffer.afterCreateImage', $entity, $eventData);
-                                $this->_table->eventManager()->dispatch($event);
-                            }
-                        }
+                        $imagePaths = array_merge($imagePaths, $thumbnailPaths);
                     }
+                    $eventData = ['path' => $path, 'images' => $imagePaths];
+                    $event = new Event('Proffer.afterCreateImage', $entity, $eventData);
+                    $this->_table->eventManager()->dispatch($event);
                 } else {
                     throw new Exception('Cannot upload file');
                 }

--- a/tests/TestCase/Model/Behavior/ProfferBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ProfferBehaviorTest.php
@@ -494,29 +494,22 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
 
         $path = $this->_getProfferPathMock($table, $entity, 'photo');
 
-        $event0 = new Event('Proffer.afterPath', $entity, ['path' => $path]);
+        $eventAfterPath = new Event('Proffer.afterPath', $entity, ['path' => $path]);
 
         $eventManager->expects($this->at(0))
             ->method('dispatch')
-            ->with($this->equalTo($event0));
+            ->with($this->equalTo($eventAfterPath));
 
-        $event1 = new Event('Proffer.afterCreateImage', $entity, ['path' => $path, 'image' => $path->getFolder() . 'image_640x480.jpg']);
+        $images = [
+            $path->getFolder() . 'image_640x480.jpg',
+            $path->getFolder() . 'square_image_640x480.jpg',
+            $path->getFolder() . 'portrait_image_640x480.jpg',
+        ];
+        $eventAfterCreateImage = new Event('Proffer.afterCreateImage', $entity, ['path' => $path, 'images' => $images]);
 
         $eventManager->expects($this->at(1))
             ->method('dispatch')
-            ->with($this->equalTo($event1));
-
-        $event2 = new Event('Proffer.afterCreateImage', $entity, ['path' => $path, 'image' => $path->getFolder() . 'square_image_640x480.jpg']);
-
-        $eventManager->expects($this->at(2))
-            ->method('dispatch')
-            ->with($this->equalTo($event2));
-
-        $event3 = new Event('Proffer.afterCreateImage', $entity, ['path' => $path, 'image' => $path->getFolder() . 'portrait_image_640x480.jpg']);
-
-        $eventManager->expects($this->at(3))
-            ->method('dispatch')
-            ->with($this->equalTo($event3));
+            ->with($this->equalTo($eventAfterCreateImage));
 
         $Proffer = $this->getMockBuilder('Proffer\Model\Behavior\ProfferBehavior')
             ->setConstructorArgs([$table, $this->config])


### PR DESCRIPTION
Hi,
when I use afterCreateImage and beforeDeleteFolder events in my own project,
I found a problem:

When original image is deleted after upload to S3 in first afterCreateImage event, creating thumbnail process after that is failed.

So I fix beforeSave to pass all image paths in only one afterCreateImage event.