### PR TITLE
Edit to enable multiple file upload per field

### DIFF
--- a/src/Lib/ProfferPath.php
+++ b/src/Lib/ProfferPath.php
@@ -37,6 +37,7 @@ class ProfferPath implements ProfferPathInterface
      */
     public function __construct(Table $table, Entity $entity, $field, array $settings)
     {
+        //debug($entity);
         if (isset($settings['root'])) {
             $this->setRoot($settings['root']);
         } else {
@@ -51,7 +52,9 @@ class ProfferPath implements ProfferPathInterface
             $this->setPrefixes($settings['thumbnailSizes']);
         }
 
-        $this->setFilename($entity->get($field));
+        //$this->setFilename($entity->get($field));
+        $this->setFilename($entity);
+        
     }
 
     /**
@@ -157,7 +160,8 @@ class ProfferPath implements ProfferPathInterface
      */
     public function setFilename($filename)
     {
-        if (is_array($filename) && isset($filename['name'])) {
+        //if (is_array($filename) && isset($filename['name'])) {
+        if (isset($filename['name'])) {
             $this->filename = $filename['name'];
         } else {
             $this->filename = $filename;
@@ -196,7 +200,7 @@ class ProfferPath implements ProfferPathInterface
     public function generateSeed($seed = null)
     {
         if ($seed) {
-            return $seed;
+            //return $seed;
         }
 
         return Text::uuid();


### PR DESCRIPTION
As discussed, here is my solution that enables multiple uploads on a single field.

My approach is to loop the array of files. When an entity hasMany images or photos the patchEntity creates an array of Objects, therefore the behavior loops the objects. But a single file upload is just a flat single array so in this case I push the array into another array so that the structure of the two upload types is matched. There are also some changes to how the path and filename are extracted from the data which is submitted, looks like you were operating on the object directly. In my edits you will see that I work on the var which the foreach creates.

Not sure my solution is the most elegant or efficient but it work and I am able to upload multiple files on the single field as well as single uploads when the relation is a hasOne.

Be interested to have your feedback! TY!