### PR TITLE
Multiple file input

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,12 +97,12 @@ Which Intervention engine to use to convert the images. Defaults to PHP's GD lib
 ###pathClass
 **optional**
 If you want to inject your own class for dealing with paths you can specify it here as a fully qualified namespace.
-Eg, `'App\Lib\Proffer\AvatarPath'`.
+Eg, `'pathClass' => App\Lib\Proffer\AvatarPath::class`
 
 ###transformClass
 **optional**
 If you want to replace the creation of thumbnails you can specify your own class here, it must be a fully qualified namespace.
-EG, `'App\Lib\Proffer\WatermarkThumbnail'`.
+EG, `'transformClass' => App\Lib\Proffer\WatermarkThumbnail::class`.
 
 ## Associating many uploads to a parent
 If you need to associate many uploads to a single parent entity, the same process as above applies, but you should attach 
@@ -112,14 +112,13 @@ Let's look at an example.
 
 ```php
 // Posts hasMany Uploads
-
-// ! Remember to add a `post_id` field to your uploads database table.
+// ! Remember to add a `post_id` field to your associated `uploads` database table.
 
 // App\Model\Table\PostsTable::initialize
 $this->hasMany('Uploads');
 
 // App\Model\Table\UploadsTable::initialize
-$this->loadBehavior('Proffer.Proffer', [
+$this->addBehavior('Proffer.Proffer', [
     'filename' => [
         'dir' => 'file_dir'
     ]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,6 +104,42 @@ Eg, `'App\Lib\Proffer\AvatarPath'`.
 If you want to replace the creation of thumbnails you can specify your own class here, it must be a fully qualified namespace.
 EG, `'App\Lib\Proffer\WatermarkThumbnail'`.
 
+## Associating many uploads to a parent
+If you need to associate many uploads to a single parent entity, the same process as above applies, but you should attach 
+and configure the behaviour on the association.
+
+Let's look at an example.
+
+```php
+// Posts hasMany Uploads
+
+// ! Remember to add a `post_id` field to your uploads database table.
+
+// App\Model\Table\PostsTable::initialize
+$this->hasMany('Uploads');
+
+// App\Model\Table\UploadsTable::initialize
+$this->loadBehavior('Proffer.Proffer', [
+    'filename' => [
+        'dir' => 'file_dir'
+    ]
+]);
+```
+
+Now, when you save a post, with associated Uploads data, each upload will be converted to an entity, and saved.
+
+### Uploading multiple files
+So now you've configured the behaviour and created the table associations, you'll need to get the request data. If you're 
+using HTML5, then you can use the file input, with the `multiple` flag, to allow for multiple file upload fields. Older 
+browsers will see this as a single file upload field instead of multiple.
+
+:warning: Note that the field name is an array!
+
+```php
+// Template/Posts/add.ctp
+echo $this->Form->input('filename[]', ['type' => 'file', 'multiple' => true, 'label' => 'Files to upload']);
+```
+
 ## Configuring your templates
 You will need to make sure that your forms are using the file type so that the files can be uploaded.
 

--- a/src/Exception/CannotUploadFileException.php
+++ b/src/Exception/CannotUploadFileException.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * MoveCopyException.php
+ *
+ * @author David Yell <dyell@ukwebmedia.com>
+ * @copyright 2017 UK Web Media Ltd
+ */
+
+namespace Proffer\Exception;
+
+class CannotUploadFileException extends \Exception
+{
+
+}

--- a/src/Exception/InvalidClassException.php
+++ b/src/Exception/InvalidClassException.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * InvalidClassException.php
+ *
+ * @author David Yell <dyell@ukwebmedia.com>
+ * @copyright 2017 UK Web Media Ltd
+ */
+
+namespace Proffer\Exception;
+
+use Exception;
+
+class InvalidClassException extends Exception
+{
+
+}

--- a/src/Lib/ImageTransform.php
+++ b/src/Lib/ImageTransform.php
@@ -152,7 +152,7 @@ class ImageTransform implements ImageTransformInterface
     {
         return $image->resize($width, $height);
     }
-    
+
     /**
      * Call any method from the intervention library
      *

--- a/src/Model/Behavior/ProfferBehavior.php
+++ b/src/Model/Behavior/ProfferBehavior.php
@@ -83,7 +83,7 @@ class ProfferBehavior extends Behavior
 
             if ($entity->has($field) && is_array($entity->get($field)) && $entity->get($field)['error'] === UPLOAD_ERR_OK) {
                 $this->process($field, $settings, $entity, $path);
-            } elseif ($entity instanceof $tableEntityClass && $entity->get('error') === UPLOAD_ERR_OK) {
+            } elseif ($tableEntityClass !== null && $entity instanceof $tableEntityClass && $entity->get('error') === UPLOAD_ERR_OK) {
                 $filename = $entity->get('name');
                 $entity->set($field, $filename);
 
@@ -107,6 +107,8 @@ class ProfferBehavior extends Behavior
      * @param \Proffer\Lib\ProfferPathInterface|null $path Inject an instance of ProfferPath
      *
      * @throws \Exception If the file cannot be renamed / moved to the correct path
+     *
+     * @return void
      */
     protected function process($field, array $settings, EntityInterface $entity, ProfferPathInterface $path = null)
     {
@@ -147,7 +149,7 @@ class ProfferBehavior extends Behavior
     /**
      * Load a path class instance and create the path for the uploads to be moved into
      *
-     * @param \Cake\Datasource\EntityInterface $entity
+     * @param \Cake\Datasource\EntityInterface $entity Instance of the entity
      * @param string $field The upload field name
      * @param array $settings Array of upload settings for the field
      * @param \Proffer\Lib\ProfferPathInterface|null $path Inject an instance of ProfferPath
@@ -177,9 +179,9 @@ class ProfferBehavior extends Behavior
      * Create a new image transform instance, and create any configured thumbnails; if the upload is an image and there
      * are thumbnails configured.
      *
-     * @param \Cake\Datasource\EntityInterface $entity
-     * @param array $settings
-     * @param \Proffer\Lib\ProfferPathInterface $path
+     * @param \Cake\Datasource\EntityInterface $entity Instance of the entity
+     * @param array $settings Array of upload field settings
+     * @param \Proffer\Lib\ProfferPathInterface $path Instance of the path class
      *
      * @return void
      */

--- a/src/Model/Behavior/ProfferBehavior.php
+++ b/src/Model/Behavior/ProfferBehavior.php
@@ -101,13 +101,20 @@ class ProfferBehavior extends Behavior
     {
         $path = $this->createPath($entity, $field, $settings, $path);
 
-        if ($this->moveUploadedFile($entity->get($field)['tmp_name'], $path->fullPath())) {
-            $entity->set($field, $path->getFilename());
-            $entity->set($settings['dir'], $path->getSeed());
+        $uploadList = $entity->get($field);
+        if (count(array_filter(array_keys($entity->get($field)), 'is_string')) > 0) {
+            $uploadList = [$entity->get($field)];
+        }
 
-            $this->createThumbnails($entity, $settings, $path);
-        } else {
-            throw new Exception('Cannot upload file');
+        foreach ($uploadList as $upload) {
+            if ($this->moveUploadedFile($upload['tmp_name'], $path->fullPath())) {
+                $entity->set($field, $path->getFilename());
+                $entity->set($settings['dir'], $path->getSeed());
+
+                $this->createThumbnails($entity, $settings, $path);
+            } else {
+                throw new Exception('Cannot upload file');
+            }
         }
 
         unset($path);

--- a/src/Model/Behavior/ProfferBehavior.php
+++ b/src/Model/Behavior/ProfferBehavior.php
@@ -113,7 +113,7 @@ class ProfferBehavior extends Behavior
         $path = $this->createPath($entity, $field, $settings, $path);
         $tableEntityClass = $this->_table->entityClass();
 
-        if ($entity instanceof $tableEntityClass) {
+        if ($tableEntityClass !== null && $entity instanceof $tableEntityClass) {
             $uploadList = [
                 [
                     'name' => $entity->get('name'),

--- a/tests/Stubs/BadPath.php
+++ b/tests/Stubs/BadPath.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * BadPath.php
+ *
+ * @author David Yell <dyell@ukwebmedia.com>
+ * @copyright 2017 UK Web Media Ltd
+ */
+
+namespace Proffer\Tests\Stubs;
+
+class BadPath
+{
+
+}

--- a/tests/TestCase/Model/Validation/ProfferRulesTest.php
+++ b/tests/TestCase/Model/Validation/ProfferRulesTest.php
@@ -15,7 +15,7 @@ class ProfferRulesTest extends PHPUnit_Framework_TestCase
     {
         $this->Rules = new ProfferRules;
     }
-    
+
     public function providerDimensions()
     {
         return [
@@ -45,7 +45,7 @@ class ProfferRulesTest extends PHPUnit_Framework_TestCase
             ],
         ];
     }
-    
+
     /**
      * @dataProvider providerDimensions
      */


### PR DESCRIPTION
Resolves #207 #192 

Created a new feature in the plugin which means that it now copes with `hasMany` type associations, and can save multiple uploads associated to a single parent.

I've also refactored a number of parts of the core behaviour to make the behaviours methods smaller and easier to work with.

A new test has been added which covers saving an upload if it's an entity in itself.

Documentation has been updated accordingly.

Proposed version `0.8.0`