### PR TITLE
Add orientate method

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,12 +49,13 @@ Additional thumbnail generation types are available using the `crop` and `fit` o
 'portrait' => [
     'w' => 150,
     'h' => 300,
-    'crop' => true
+    'crop' => true,
+    'orientate' => true
 ]
 ```
 
 #### Fit
-> Combine cropping and resizing to format image in a smart way. The method will find the best fitting aspect ratio of 
+> Combine cropping and resizing to format image in a smart way. The method will find the best fitting aspect ratio of
 > your given width and height on the current image automatically, cut it out and resize it to the given dimension.
 See [Intervention Fit method](http://image.intervention.io/api/fit)
 
@@ -62,6 +63,10 @@ See [Intervention Fit method](http://image.intervention.io/api/fit)
 > Cut out a rectangular part of the current image with given width and height.
 By default, will be the centre of the image.
 See [Intervention Crop method](http://image.intervention.io/api/crop)
+
+#### Orientate
+> Reads the EXIF image profile setting 'Orientation' and performs a rotation on the image to display the image correctly.
+See [Intervention Orientate method](http://image.intervention.io/api/orientate) for PHP installation requirements.
 
 ## Template
 In order to upload a file to your application you will need to add the form fields to your view.
@@ -105,7 +110,7 @@ If you want to replace the creation of thumbnails you can specify your own class
 EG, `'transformClass' => App\Lib\Proffer\WatermarkThumbnail::class`.
 
 ## Associating many uploads to a parent
-If you need to associate many uploads to a single parent entity, the same process as above applies, but you should attach 
+If you need to associate many uploads to a single parent entity, the same process as above applies, but you should attach
 and configure the behaviour on the association.
 
 Let's look at an example.
@@ -128,8 +133,8 @@ $this->addBehavior('Proffer.Proffer', [
 Now, when you save a post, with associated Uploads data, each upload will be converted to an entity, and saved.
 
 ### Uploading multiple files
-So now you've configured the behaviour and created the table associations, you'll need to get the request data. If you're 
-using HTML5, then you can use the file input, with the `multiple` flag, to allow for multiple file upload fields. Older 
+So now you've configured the behaviour and created the table associations, you'll need to get the request data. If you're
+using HTML5, then you can use the file input, with the `multiple` flag, to allow for multiple file upload fields. Older
 browsers will see this as a single file upload field instead of multiple.
 
 :warning: Note that the field name is an array!

--- a/src/Lib/ImageTransform.php
+++ b/src/Lib/ImageTransform.php
@@ -88,6 +88,10 @@ class ImageTransform implements ImageTransformInterface
 
         $image = $this->ImageManager->make($this->Path->fullPath());
 
+        if (!empty($config['orientate'])) {
+            $image = $this->orientate($image);
+        }
+
         if (!empty($config['crop'])) {
             $image = $this->thumbnailCrop($image, $width, $height);
         } elseif (!empty($config['fit'])) {
@@ -98,7 +102,7 @@ class ImageTransform implements ImageTransformInterface
             $image = $this->thumbnailResize($image, $width, $height);
         }
 
-        unset($config['crop'], $config['w'], $config['h'], $config['custom'], $config['params']);
+        unset($config['crop'], $config['w'], $config['h'], $config['custom'], $config['params'], $config['orientate']);
 
         $image->save($this->Path->fullPath($prefix), $config['jpeg_quality']);
 
@@ -167,5 +171,18 @@ class ImageTransform implements ImageTransformInterface
     protected function thumbnailCustom(Image $image, $custom, $params)
     {
         return call_user_func_array([$image, $custom], $params);
+    }
+
+    /**
+     * EXIF orientate the current image
+     *
+     * @see http://image.intervention.io/api/orientate
+     *
+     * @param \Intervention\Image\Image $image Image instance
+     * @return \Intervention\Image\Image
+     */
+    protected function orientate(Image $image)
+    {
+        return $image->orientate();
     }
 }

--- a/tests/TestCase/Model/Behavior/ProfferBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ProfferBehaviorTest.php
@@ -35,6 +35,7 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
             'thumbnailSizes' => [
                 'square' => ['w' => 200, 'h' => 200, 'crop' => true],
                 'portrait' => ['w' => 100, 'h' => 300],
+                'large' => ['w' => 1200, 'h' => 900, 'orientate' => true],
             ]
         ]
     ];
@@ -99,7 +100,8 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
             ->with($this->logicalOr(
                 $this->equalTo(null),
                 $this->equalTo('square'),
-                $this->equalTo('portrait')
+                $this->equalTo('portrait'),
+                $this->equalTo('large')
             ))
             ->will($this->returnCallback(
                 function ($param) use ($table, $entity) {
@@ -545,6 +547,7 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
             $path->getFolder() . 'image_640x480.jpg',
             $path->getFolder() . 'square_image_640x480.jpg',
             $path->getFolder() . 'portrait_image_640x480.jpg',
+            $path->getFolder() . 'large_image_640x480.jpg',
         ];
         $eventAfterCreateImage = new Event('Proffer.afterCreateImage', $entity, ['path' => $path, 'images' => $images]);
 


### PR DESCRIPTION
Apparently iOS photos determine their orientation only by EXIF data, so I was running into cases where processed images would have the wrong orientation. The Intervention [orientate](http://image.intervention.io/api/orientate) method fixes this, so this PR adds it as an additional thumbnail option. 