### PR TITLE
Cleaning up `fullPath()` method and fixes always injecting `seed` to path.

### DIFF
--- a/src/Lib/ProfferPath.php
+++ b/src/Lib/ProfferPath.php
@@ -211,17 +211,11 @@ class ProfferPath implements ProfferPathInterface
      */
     public function fullPath($prefix = null)
     {
-        $table = $this->getTable();
-        $table = (!empty($table)) ? $table . DS : null;
-
-        $seed = $this->getSeed();
-        $seed = (!empty($seed)) ? $seed . DS : null;
-
         if ($prefix) {
-            return $this->getRoot() . DS . $table . $this->getField() . DS . $this->getSeed() . DS . $prefix . '_' . $this->getFilename();
+            return $this->getFolder() . $prefix . '_' . $this->getFilename();
         }
 
-        return $this->getRoot() . DS . $table . $this->getField() . DS . $seed . $this->getFilename();
+        return $this->getFolder() . $this->getFilename();
     }
 
     /**


### PR DESCRIPTION
It makes `fullPath()` method dry and fixes always injecting `seed` (if it's null or not) for calculated path if the `prefix` is set.