### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,4 +1,4 @@
-#Configuration
+# Configuration
 This manual page relates to how to configure the Proffer behaviour, what the configuration options do, their defaults and how to change them.
 
 ## Configuring the behaviour in your table
@@ -78,33 +78,33 @@ echo $this->Form->end();
 ```
 This will turn your form into a multipart form and add the relevant fields.
 
-##Configuration options
+## Configuration options
 There are a number of configuration options you can pass into the behaviour when you attach it to your table. These options are passed as an array value of the upload field.
 
-###dir
+### dir
 **required** `string`
 The database field which will store the name of the folder in which the files are uploaded.
 
-###thumbnailSizes
+### thumbnailSizes
 **optional** `array`
 An array of sizes to create thumbnails of an uploaded image. The format is that the image prefix will be the array key and the sizes are the value as an array.
 Eg, `'square' => ['w' => 200, 'h' => 200]` would create a thumbnail prefixed with `square_` and would be 100px x 100px.
 If you do not specify the `thumbnailSizes` configuration option, no thumbnails will be created.
 
-###root
+### root
 **optional:** defaults to, `WWW_DIR . 'files'`
 Allows you to customise the root folder in which all the file upload folders and files will be created.
 
-###thumbnailMethod
+### thumbnailMethod
 **optional:** defaults to, `gd`
 Which Intervention engine to use to convert the images. Defaults to PHP's GD library. Can also be `imagick`.
 
-###pathClass
+### pathClass
 **optional**
 If you want to inject your own class for dealing with paths you can specify it here as a fully qualified namespace.
 Eg, `'pathClass' => App\Lib\Proffer\AvatarPath::class`
 
-###transformClass
+### transformClass
 **optional**
 If you want to replace the creation of thumbnails you can specify your own class here, it must be a fully qualified namespace.
 EG, `'transformClass' => App\Lib\Proffer\WatermarkThumbnail::class`.

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -1,10 +1,10 @@
-#Customisation
+# Customisation
 This manual page deals with customising the behaviour of the Proffer plugin. How to change the upload location and changing
 file names. It also cover how you can use the Proffer events to change the way the plugin behaves.
 
-##Customising using an event listener
+## Customising using an event listener
 
-###Customising upload file names and paths
+### Customising upload file names and paths
 Using the `Proffer.afterPath` event you can hook into all the details about the file upload before it is processed. Using
 this event you can change the name of the file and the upload path to match whatever convention you want. I have created
 an example listener which is [available as an example](examples/UploadFilenameListener.md).
@@ -25,12 +25,12 @@ file and also attach this listener to multiple tables, if you wanted the same na
 :warning: The listener will overwrite any settings that are configured in the path class. This includes if you are using
 your own path class.
 
-###Customising behavior of file creation/deletion
+### Customising behavior of file creation/deletion
 Proffer’s image creation can be hooked by using `Proffer.afterCreateImage` event, and by using `Proffer.beforeDeleteImage` event, Proffer’s image deletion can be hooked.
 These events can be used to copy files to external services (e.g. Amazon S3), or deleting files from external services at the same time of Proffer creating/deleting images.
 I have created an example listener which is [available as an example](examples/UploadAndDeleteImageListener.md).
 
-##Advanced customisation
+## Advanced customisation
 If you want more control over how the plugin is handling paths or creating thumbnails you can replace these components
 with your own by creating a class using the provided interfaces and injecting them into the plugin.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,8 +1,8 @@
-#Examples
+# Examples
 This manual page shows some examples of how to customise the behaviour of the plugin,
 as well as event listeners and image display.
 
-##Displaying uploaded images
+## Displaying uploaded images
 You can use the `HtmlHelper` to link the images. Just make sure that you have both upload fields in the data set to the view.
 This is what it would look like if you're using the defaults, if you've implemented your own path class, you will need
 to update the paths accordingly.
@@ -15,12 +15,12 @@ Here are some basic event listener example classes
 * [Customize the upload folder and filename](examples/UploadFilenameListener.md)
 * [Customize behavior of file creation/deletion](examples/UploadAndDeleteImageListener.md)
 
-##Uploading multiple related images
+## Uploading multiple related images
 This example will show you how to upload many images which are related to your
 current table class. An example setup might be that you have a `Users` table class
 and a `UserImages` table class. The example below is just [baked code](http://book.cakephp.org/3.0/en/bake/usage.html).
 
-###Tables
+### Tables
 The relationships are setup as follows. Be sure to attach the behavior to the
 table class which is receiving the uploads.
 
@@ -42,11 +42,11 @@ $this->addBehavior('Proffer.Proffer', [
 $this->belongsTo('Users', ['foreignKey' => 'user_id', 'joinType' => 'INNER']);
 ```
 
-###Entities
+### Entities
 Your entity must allow the associated field in it's `$_accessible` array. So in our
 example we need to check that the `'user_images' => true` is included in our `User` entity.
 
-###Controller
+### Controller
 No changes need to be made to standard controller code as Cake will automatically save any
 first level associated data by default. As our `Users` table is directly associated with
 our `UserImages` table, we don't need to change anything.
@@ -55,7 +55,7 @@ If you were working with a related models data, you would need to specify the as
 to populate when [merging the entity data](http://book.cakephp.org/3.0/en/orm/saving-data.html#converting-request-data-into-entities)
 using the `'associated'` key.
 
-###Templates
+### Templates
 You will need to include the related fields in your templates using the correct
 field names, so that your request data is formatted correctly.
 
@@ -74,7 +74,7 @@ field names, so that your request data is formatted correctly.
 How you deal with the display of existing images, deletion of existing images,
 and adding of new upload fields is up to you, and outside the scope of this example.
 
-###Deleting images but preserving data
+### Deleting images but preserving data
 If you need to delete an upload and remove it's associated data from your data store, you can achieve this in your controller.
 
 The easiest way is to add a checkbox to your form and then look for it when processing your post data.

--- a/docs/examples/UploadAndDeleteImageListener.md
+++ b/docs/examples/UploadAndDeleteImageListener.md
@@ -1,8 +1,8 @@
-##Customizing behavior of file creation/deletion using event listener
+## Customizing behavior of file creation/deletion using event listener
 
 You can hook Proffer's image creation/deletion as below.
 
-###Create src/Event/UploadAndDeleteImageListener.php
+### Create src/Event/UploadAndDeleteImageListener.php
 
 ```php
 <?php
@@ -41,7 +41,7 @@ class UploadAndDeleteImageListener implements EventListenerInterface {
 }
 ```
 
-###Register listener to EventManager in config/bootstrap.php
+### Register listener to EventManager in config/bootstrap.php
 
 ```php
 Cake\Event\EventManager::instance()->on(new \App\Event\UploadAndDeleteImageListener());

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,4 +1,4 @@
-#Frequently asked questions
+# Frequently asked questions
 This manual page collects together all the frequent questions about the plugin, it's functionality and some of the more
 common errors people might experience.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,4 +1,4 @@
-#Installation
+# Installation
 This manual page deals with the installation of the Proffer plugin. Where you can get the code and where should it be in your project.
 
 ## Packagist

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -1,7 +1,7 @@
-#Proffer shell tasks
+# Proffer shell tasks
 This manual page deals with the command line tools which are included with the Proffer plugin.
 
-##Getting available tasks
+## Getting available tasks
 Proffer comes with a built in shell which can help you achieve certain things when dealing with your uploaded files. To
 find out more about the shell you can use the following command to output the help and options.
 
@@ -9,7 +9,7 @@ find out more about the shell you can use the following command to output the he
 $ bin/cake proffer
 ```
 
-##Regenerate thumbnail task
+## Regenerate thumbnail task
 If you would like to regenerate the thumbnails for files already on your system, or you've changed your configuration. You
 can use the built-in shell to regenerate the thumbnails for a table.
 
@@ -26,7 +26,7 @@ This example shows regenerating thumbnails for the `UserImages` table class, usi
 $ bin/cake proffer generate -p \\App\\Lib\\Proffer\\UserImagePath UserImages
 ```
 
-##Cleanup task
+## Cleanup task
 The cleanup task will look at a model's uploads folder and match the files there with its matching entry in the
 database. If a file doesn't have a matching record in the database it **will be deleted**.
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,8 +1,8 @@
-#Validation
+# Validation
 This manual page deals with how to use the included ProfferRules validation provider to add upload related validation rules to
 your application.
 
-##Built-in validation provider
+## Built-in validation provider
 Proffer comes an extra validation rule to check the dimensions of an uploaded image. Other rules are provided by the core and are listed below.
 
 In your validation function in your table class you'll need to add the validator as a provider and then apply the rules.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
