### PR TITLE
Use non-deprecated methods

### DIFF
--- a/src/Database/Type/FileType.php
+++ b/src/Database/Type/FileType.php
@@ -11,9 +11,9 @@
 
 namespace Proffer\Database\Type;
 
-use Cake\Database\Type;
+use Cake\Database\Type\StringType;
 
-class FileType extends Type
+class FileType extends StringType
 {
     /**
      * Prevent the marhsaller changing the upload array into a string

--- a/src/Lib/ProfferPath.php
+++ b/src/Lib/ProfferPath.php
@@ -43,7 +43,7 @@ class ProfferPath implements ProfferPathInterface
             $this->setRoot(WWW_ROOT . 'files');
         }
 
-        $this->setTable($table->alias());
+        $this->setTable($table->getAlias());
         $this->setField($field);
         $this->setSeed($this->generateSeed($entity->get($settings['dir'])));
 

--- a/src/Model/Behavior/ProfferBehavior.php
+++ b/src/Model/Behavior/ProfferBehavior.php
@@ -35,11 +35,11 @@ class ProfferBehavior extends Behavior
     public function initialize(array $config)
     {
         Type::map('proffer.file', '\Proffer\Database\Type\FileType');
-        $schema = $this->_table->schema();
-        foreach (array_keys($this->config()) as $field) {
-            $schema->columnType($field, 'proffer.file');
+        $schema = $this->_table->getSchema();
+        foreach (array_keys($this->getConfig()) as $field) {
+            $schema->setColumnType($field, 'proffer.file');
         }
-        $this->_table->schema($schema);
+        $this->_table->setSchema($schema);
     }
 
     /**
@@ -55,8 +55,8 @@ class ProfferBehavior extends Behavior
      */
     public function beforeMarshal(Event $event, ArrayObject $data, ArrayObject $options)
     {
-        foreach ($this->config() as $field => $settings) {
-            if ($this->_table->validator()->isEmptyAllowed($field, false) &&
+        foreach ($this->getConfig() as $field => $settings) {
+            if ($this->_table->getValidator()->isEmptyAllowed($field, false) &&
                 isset($data[$field]['error']) && $data[$field]['error'] === UPLOAD_ERR_NO_FILE
             ) {
                 unset($data[$field]);
@@ -81,8 +81,8 @@ class ProfferBehavior extends Behavior
     public function beforeSave(Event $event, EntityInterface $entity, ArrayObject $options, ProfferPathInterface $path = null)
     {
 
-        foreach ($this->config() as $field => $settings) {
-            $tableEntityClass = $this->_table->entityClass();
+        foreach ($this->getConfig() as $field => $settings) {
+            $tableEntityClass = $this->_table->getEntityClass();
 
             if ($entity->has($field) && is_array($entity->get($field)) && $entity->get($field)['error'] === UPLOAD_ERR_OK) {
                 $this->process($field, $settings, $entity, $path);
@@ -169,7 +169,7 @@ class ProfferBehavior extends Behavior
         }
 
         $event = new Event('Proffer.afterPath', $entity, ['path' => $path]);
-        $this->_table->eventManager()->dispatch($event);
+        $this->_table->getEventManager()->dispatch($event);
         if (!empty($event->result)) {
             $path = $event->result;
         }
@@ -210,7 +210,7 @@ class ProfferBehavior extends Behavior
 
             $eventData = ['path' => $path, 'images' => $imagePaths];
             $event = new Event('Proffer.afterCreateImage', $entity, $eventData);
-            $this->_table->eventManager()->dispatch($event);
+            $this->_table->getEventManager()->dispatch($event);
         }
     }
 
@@ -228,7 +228,7 @@ class ProfferBehavior extends Behavior
      */
     public function afterDelete(Event $event, EntityInterface $entity, ArrayObject $options, ProfferPathInterface $path = null)
     {
-        foreach ($this->config() as $field => $settings) {
+        foreach ($this->getConfig() as $field => $settings) {
             $dir = $entity->get($settings['dir']);
 
             if (!empty($entity) && !empty($dir)) {
@@ -239,7 +239,7 @@ class ProfferBehavior extends Behavior
                 }
 
                 $event = new Event('Proffer.beforeDeleteFolder', $entity, ['path' => $path]);
-                $this->_table->eventManager()->dispatch($event);
+                $this->_table->getEventManager()->dispatch($event);
                 $path->deleteFiles($path->getFolder(), true);
             }
 

--- a/tests/Stubs/TestPath.php
+++ b/tests/Stubs/TestPath.php
@@ -21,7 +21,7 @@ class TestPath extends ProfferPath
     {
         $this->setRoot(TMP . 'ProfferTests');
 
-        $this->setTable($table->alias());
+        $this->setTable($table->getAlias());
         $this->setField($field);
         $this->setSeed('proffer_test');
 

--- a/tests/TestCase/Lib/ProfferPathTest.php
+++ b/tests/TestCase/Lib/ProfferPathTest.php
@@ -115,9 +115,9 @@ class ProfferPathTest extends PHPUnit_Framework_TestCase
     public function testConstructedFullPath($data, $expected)
     {
         $table = $this->getMockBuilder('Cake\ORM\Table')
-            ->setMethods(['alias'])
+            ->setMethods(['getAlias'])
             ->getMock();
-        $table->method('alias')
+        $table->method('getAlias')
             ->willReturn('ProfferTest');
 
         $entity = new Entity($data['entity']);
@@ -136,9 +136,9 @@ class ProfferPathTest extends PHPUnit_Framework_TestCase
     public function testGetFolder()
     {
         $table = $this->getMockBuilder('Cake\ORM\Table')
-            ->setMethods(['alias'])
+            ->setMethods(['getAlias'])
             ->getMock();
-        $table->method('alias')
+        $table->method('getAlias')
             ->willReturn('ProfferTest');
 
         $entity = new Entity([
@@ -165,9 +165,9 @@ class ProfferPathTest extends PHPUnit_Framework_TestCase
     public function testPrefixes()
     {
         $table = $this->getMockBuilder('Cake\ORM\Table')
-            ->setMethods(['alias'])
+            ->setMethods(['getAlias'])
             ->getMock();
-        $table->method('alias')
+        $table->method('getAlias')
             ->willReturn('ProfferTest');
 
         $entity = new Entity([
@@ -194,9 +194,9 @@ class ProfferPathTest extends PHPUnit_Framework_TestCase
     public function testDeleteFiles()
     {
         $table = $this->getMockBuilder('Cake\ORM\Table')
-            ->setMethods(['alias'])
+            ->setMethods(['getAlias'])
             ->getMock();
-        $table->method('alias')
+        $table->method('getAlias')
             ->willReturn('ProfferTest');
 
         $entity = new Entity([
@@ -220,7 +220,7 @@ class ProfferPathTest extends PHPUnit_Framework_TestCase
 
         $path->expects($this->any())
             ->method('getFolder')
-            ->willReturn(TMP . 'ProfferTests' . DS . $table->alias() . DS . 'photo' . DS . 'proffer_test' . DS);
+            ->willReturn(TMP . 'ProfferTests' . DS . $table->getAlias() . DS . 'photo' . DS . 'proffer_test' . DS);
 
         $path = new ProfferPath($table, $entity, 'photo', $settings);
 
@@ -258,9 +258,9 @@ class ProfferPathTest extends PHPUnit_Framework_TestCase
     public function testCreatingPathFolderWhichExists()
     {
         $table = $this->getMockBuilder('Cake\ORM\Table')
-            ->setMethods(['alias'])
+            ->setMethods(['getAlias'])
             ->getMock();
-        $table->method('alias')
+        $table->method('getAlias')
             ->willReturn('ProfferTest');
 
         $entity = new Entity([

--- a/tests/TestCase/Model/Behavior/ProfferBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ProfferBehaviorTest.php
@@ -9,7 +9,7 @@ namespace Proffer\Tests\Model\Behavior;
 
 use ArrayObject;
 use Cake\Core\Plugin;
-use Cake\Database\Schema\Table as TableSchema;
+use Cake\Database\Schema\TableSchema;
 use Cake\Event\Event;
 use Cake\Event\EventListenerInterface;
 use Cake\Event\EventManager;
@@ -118,14 +118,14 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
                         $filename .= $entityFieldData;
                     }
 
-                    return TMP . 'ProfferTests' . DS . $table->alias() .
+                    return TMP . 'ProfferTests' . DS . $table->getAlias() .
                         DS . 'photo' . DS . 'proffer_test' . DS . $filename;
                 }
             ));
 
         $path->expects($this->any())
             ->method('getFolder')
-            ->willReturn(TMP . 'ProfferTests' . DS . $table->alias() . DS . 'photo' . DS . 'proffer_test' . DS);
+            ->willReturn(TMP . 'ProfferTests' . DS . $table->getAlias() . DS . 'photo' . DS . 'proffer_test' . DS);
 
         return $path;
     }
@@ -170,23 +170,23 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
      */
     public function testBeforeMarshal(array $data, $allowEmpty, array $expected)
     {
-        $schema = $this->createMock(TableSchema::class, null, ['examples']);
-        $table = $this->createMock(Table::class, ['alias'], [['schema' => $schema]]);
-        $table->method('alias')
+        $schema = $this->createMock(TableSchema::class);
+        $table = $this->createMock(Table::class);
+        $table->method('getAlias')
             ->willReturn('ProfferTest');
-        $table->method('schema')
+        $table->method('getSchema')
             ->willReturn($schema);
 
         $proffer = new ProfferBehavior($table, $this->config);
 
         $validator = $this->createMock(Validator::class);
-        $table->validator('test', $validator);
+        $table->setValidator('test', $validator);
 
-        $table->method('validator')
+        $table->method('getValidator')
             ->willReturn($validator);
 
         if ($allowEmpty) {
-            $table->validator()->allowEmpty('photo');
+            $table->getValidator()->allowEmpty('photo');
         }
 
         $arrayObject = new ArrayObject($data);
@@ -270,11 +270,11 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
         $schema = $this->createMock(TableSchema::class);
         $table = $this->createMock(Table::class);
         $eventManager = $this->createMock(EventManager::class);
-        $table->method('alias')
+        $table->method('getAlias')
             ->willReturn('ProfferTest');
-        $table->method('schema')
+        $table->method('getSchema')
             ->willReturn($schema);
-        $table->method('eventManager')
+        $table->method('getEventManager')
             ->willReturn($eventManager);
 
         $entity = new Entity($entityData);
@@ -290,7 +290,7 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
             ->willReturnCallback(function ($source, $destination) {
                 if (!file_exists(pathinfo($destination, PATHINFO_DIRNAME))) {
                     mkdir(pathinfo($destination, PATHINFO_DIRNAME), 0777, true);
-                }
+            }
 
                 return copy($source, $destination);
             });
@@ -327,11 +327,11 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
         $schema = $this->createMock(TableSchema::class);
         $table = $this->createMock(Table::class);
         $eventManager = $this->createMock(EventManager::class);
-        $table->method('alias')
+        $table->method('getAlias')
             ->willReturn('ProfferTest');
-        $table->method('schema')
+        $table->method('getSchema')
             ->willReturn($schema);
-        $table->method('eventManager')
+        $table->method('getEventManager')
             ->willReturn($eventManager);
 
         $path = $this->_getProfferPathMock(
@@ -374,11 +374,11 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
         $schema = $this->createMock(TableSchema::class);
         $table = $this->createMock(Table::class);
         $eventManager = $this->createMock(EventManager::class);
-        $table->method('alias')
+        $table->method('getAlias')
             ->willReturn('ProfferTest');
-        $table->method('schema')
+        $table->method('getSchema')
             ->willReturn($schema);
-        $table->method('eventManager')
+        $table->method('getEventManager')
             ->willReturn($eventManager);
 
         $proffer = $this->getMockBuilder(ProfferBehavior::class)
@@ -417,11 +417,11 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
         $schema = $this->createMock(TableSchema::class);
         $eventManager = $this->createMock(EventManager::class);
         $table = $this->createMock(Table::class);
-        $table->method('alias')
+        $table->method('getAlias')
             ->willReturn('ProfferTest');
-        $table->method('schema')
+        $table->method('getSchema')
             ->willReturn($schema);
-        $table->method('eventManager')
+        $table->method('getEventManager')
             ->willReturn($eventManager);
 
         $proffer = new ProfferBehavior($table, $this->config);
@@ -473,11 +473,11 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
         $schema = $this->createMock(TableSchema::class);
         $table = $this->createMock(Table::class);
         $eventManager = $this->createMock(EventManager::class);
-        $table->method('alias')
+        $table->method('getAlias')
             ->willReturn('ProfferTest');
-        $table->method('schema')
+        $table->method('getSchema')
             ->willReturn($schema);
-        $table->method('eventManager')
+        $table->method('getEventManager')
             ->willReturn($eventManager);
 
         $proffer = new ProfferBehavior($table, $this->config);
@@ -529,10 +529,10 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
         $schema = $this->createMock(TableSchema::class);
         $table = $this->getMockBuilder(Table::class)
             ->setConstructorArgs([['eventManager' => $eventManager, 'schema' => $schema]])
-            ->setMethods(['alias'])
+            ->setMethods(['getAlias'])
             ->getMock();
 
-        $table->method('alias')
+        $table->method('getAlias')
             ->willReturn('ProfferTest');
 
         $path = $this->_getProfferPathMock($table, $entity, 'photo');
@@ -581,11 +581,11 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
         $schema = $this->createMock(TableSchema::class);
         $table = $this->createMock(Table::class);
         $eventManager = $this->createMock(EventManager::class);
-        $table->method('alias')
+        $table->method('getAlias')
             ->willReturn('ProfferTest');
-        $table->method('schema')
+        $table->method('getSchema')
             ->willReturn($schema);
-        $table->method('eventManager')
+        $table->method('getEventManager')
             ->willReturn($eventManager);
 
         $config = $this->config;
@@ -693,11 +693,11 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
         $schema = $this->createMock(TableSchema::class);
         $table = $this->createMock(Table::class);
         $eventManager = new EventManager();
-        $table->method('alias')
+        $table->method('getAlias')
             ->willReturn('ProfferTest');
-        $table->method('schema')
+        $table->method('getSchema')
             ->willReturn($schema);
-        $table->method('eventManager')
+        $table->method('getEventManager')
             ->willReturn($eventManager);
 
         $listener = $this->getMockBuilder(EventListenerInterface::class)
@@ -715,12 +715,12 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
                 $path->setSeed($pathData['seed']);
                 $path->setFilename($pathData['filename']);
 
-                $event->subject()['photo']['name'] = $pathData['filename'];
+                $event->getSubject()['photo']['name'] = $pathData['filename'];
 
                 return $path;
             });
 
-        $table->eventManager()->on($listener);
+        $table->getEventManager()->on($listener);
 
         $entityData = [
             'photo' => [
@@ -769,9 +769,9 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
     {
         $schema = $this->createMock(TableSchema::class);
         $table = $this->createMock(Table::class);
-        $table->method('alias')
+        $table->method('getAlias')
             ->willReturn('ProfferTest');
-        $table->method('schema')
+        $table->method('getSchema')
             ->willReturn($schema);
 
         $config = $this->config;
@@ -805,11 +805,11 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
         $schema = $this->createMock(TableSchema::class);
         $table = $this->createMock(Table::class);
         $eventManager = $this->createMock(EventManager::class);
-        $table->method('alias')
+        $table->method('getAlias')
             ->willReturn('ProfferTest');
-        $table->method('schema')
+        $table->method('getSchema')
             ->willReturn($schema);
-        $table->method('eventManager')
+        $table->method('getEventManager')
             ->willReturn($eventManager);
 
         $config = [
@@ -883,11 +883,11 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
         $schema = $this->createMock(TableSchema::class);
         $table = $this->createMock(Table::class);
         $eventManager = $this->createMock(EventManager::class);
-        $table->method('alias')
+        $table->method('getAlias')
             ->willReturn('ProfferTest');
-        $table->method('schema')
+        $table->method('getSchema')
             ->willReturn($schema);
-        $table->method('eventManager')
+        $table->method('getEventManager')
             ->willReturn($eventManager);
 
         $config = [
@@ -950,11 +950,11 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
         $schema = $this->createMock(TableSchema::class);
         $table = $this->createMock(Table::class);
         $eventManager = $this->createMock(EventManager::class);
-        $table->method('alias')
+        $table->method('getAlias')
             ->willReturn('ProfferTest');
-        $table->method('schema')
+        $table->method('getSchema')
             ->willReturn($schema);
-        $table->method('eventManager')
+        $table->method('getEventManager')
             ->willReturn($eventManager);
 
         $entityData = [
@@ -1051,10 +1051,10 @@ class ProfferBehaviorTest extends PHPUnit_Framework_TestCase
             ])
             ->getMock();
 
-        $uploadsTable->method('entityClass')->willReturn(Entity::class);
-        $uploadsTable->method('alias')->willReturn('Uploads');
-        $uploadsTable->method('schema')->willReturn($uploadsSchema);
-        $uploadsTable->method('eventManager')->willReturn($eventManager);
+        $uploadsTable->method('getEntityClass')->willReturn(Entity::class);
+        $uploadsTable->method('getAlias')->willReturn('Uploads');
+        $uploadsTable->method('getSchema')->willReturn($uploadsSchema);
+        $uploadsTable->method('getEventManager')->willReturn($eventManager);
 
         $config = [
             'photo' => [

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -56,7 +56,7 @@ Configure::write('Session', [
     'defaults' => 'php'
 ]);
 
-Cache::config([
+Cache::setConfig([
     '_cake_core_' => [
         'engine' => 'File',
         'prefix' => 'cake_core_',
@@ -80,7 +80,7 @@ if (!getenv('db_class')) {
     putenv('db_dsn=sqlite::memory:');
 }
 
-ConnectionManager::config('test', [
+ConnectionManager::setConfig('test', [
     'className' => 'Cake\Database\Connection',
     'driver' => getenv('db_class'),
     'dsn' => getenv('db_dsn'),
@@ -90,7 +90,7 @@ ConnectionManager::config('test', [
     'timezone' => 'UTC'
 ]);
 
-Log::config([
+Log::setConfig([
     'debug' => [
         'engine' => 'Cake\Log\Engine\FileLog',
         'levels' => ['notice', 'info', 'debug'],


### PR DESCRIPTION
This should be all that starts throwing deprecating messages in Cake 3.6