### PR TITLE
CakePHP3.6 Plugin class

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -12,19 +12,10 @@
 namespace Proffer;
 
 use Cake\Core\BasePlugin;
-use Cake\Core\Configure;
 
 /**
  * Default Plugin class
  */
 class Plugin extends BasePlugin
 {
-    /**
-     * Initialize plugin
-     *
-     * @return void
-     */
-    public function initialize()
-    {
-    }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @category Proffer
+ * @package Plugin.php
+ *
+ * @author Michel Peters <info@isemantics.nl>
+ * @when 11/06/18
+ *
+ */
+
+namespace Proffer;
+
+use Cake\Core\BasePlugin;
+use Cake\Core\Configure;
+
+/**
+ * Default Plugin class
+ */
+class Plugin extends BasePlugin
+{
+    /**
+     * Initialize plugin
+     *
+     * @return void
+     */
+    public function initialize()
+    {
+    }
+}


### PR DESCRIPTION
In src/Application.php you can use $this->addPlugin in CakePHP3.6 . This adds an empty class, so that CakePHP wont fatal from missing the /src/Plugin.php .
p.s. I hope I did this Pull Request the right way :)