### PR TITLE
Fix deleting an uploaded file

### DIFF
--- a/src/Lib/ProfferPath.php
+++ b/src/Lib/ProfferPath.php
@@ -13,6 +13,7 @@ namespace Proffer\Lib;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Table;
 use Cake\Utility\Text;
+use Psr\Http\Message\UploadedFileInterface;
 
 class ProfferPath implements ProfferPathInterface
 {
@@ -52,7 +53,11 @@ class ProfferPath implements ProfferPathInterface
             $this->setPrefixes($settings['thumbnailSizes']);
         }
 
-        $this->setFilename($entity->get($field)->getClientFilename());
+        if ($entity->get($field) instanceof UploadedFileInterface) {
+            $this->setFilename($entity->get($field)->getClientFilename());
+        } else {
+            $this->setFilename($entity->get($field));
+        }
     }
 
     /**


### PR DESCRIPTION
If we delete an uploaded file, the entity is retrieved from the database and its file field is therefore not an instance of UploadedFile, but a string. With this change, we check whether the file field is an instance of UploadedFile or a string, and ensure that the file name is correctly set.

This fixes issue #279.