### PR TITLE
Disable Upsize option + Documentation fixes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,10 @@ $this->addBehavior('Proffer.Proffer', [
 				'w' => 100,
 				'h' => 300
 			],
+			'mobile' => [			// Create a smaller copy based on width or height that respects ratio
+				'w' => 421,			// Height can be omitted
+				'upsize' => false	// Prevent the image from being upsized if it is narrower than specified width
+			]
 		],
 		'thumbnailMethod' => 'gd'	// Options are Imagick or Gd
 	]
@@ -57,16 +61,21 @@ Additional thumbnail generation types are available using the `crop` and `fit` o
 #### Fit
 > Combine cropping and resizing to format image in a smart way. The method will find the best fitting aspect ratio of
 > your given width and height on the current image automatically, cut it out and resize it to the given dimension.
-See [Intervention Fit method](http://image.intervention.io/api/fit)
+See [Intervention Fit method](https://image.intervention.io/v2/api/fit)
 
 #### Crop
 > Cut out a rectangular part of the current image with given width and height.
 By default, will be the centre of the image.
-See [Intervention Crop method](http://image.intervention.io/api/crop)
+See [Intervention Crop method](https://image.intervention.io/v2/api/crop)
 
 #### Orientate
 > Reads the EXIF image profile setting 'Orientation' and performs a rotation on the image to display the image correctly.
-See [Intervention Orientate method](http://image.intervention.io/api/orientate) for PHP installation requirements.
+See [Intervention Orientate method](https://image.intervention.io/v2/api/orientate) for PHP installation requirements.
+
+#### Upsize
+> sets $constraint->upsize(); when calling Intervention's resize function
+See [Intervention Resize method](https://image.intervention.io/v2/api/resize)
+
 
 ## Template
 In order to upload a file to your application you will need to add the form fields to your view.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,7 @@ $this->addBehavior('Proffer.Proffer', [
 				'h' => 300
 			],
 			'mobile' => [			// Create a smaller copy based on width or height that respects ratio
-				'w' => 421,			// Height can be omitted
+				'w' => 421,		// Height can be omitted (or vice versa)
 				'upsize' => false	// Prevent the image from being upsized if it is narrower than specified width
 			]
 		],

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -14,7 +14,7 @@ an example listener which is [available as an example](examples/UploadFilenameLi
 
 // Add your new custom listener
 $listener = new App\Event\LogFilenameListener();
-$this->eventManager()->on($listener);
+$this->getEventManager()->on($listener);
 ```
 
 The advantages of customisation using a listener is that you can encapsulate the file naming functionality into a single

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -26,7 +26,7 @@ file and also attach this listener to multiple tables, if you wanted the same na
 your own path class.
 
 ### Customising behavior of file creation/deletion
-Proffer’s image creation can be hooked by using `Proffer.afterCreateImage` event, and by using `Proffer.beforeDeleteImage` event, Proffer’s image deletion can be hooked.
+Proffer’s image creation can be hooked by using `Proffer.afterCreateImage` event, and by using `Proffer.beforeDeleteFolder` event, Proffer’s image deletion can be hooked.
 These events can be used to copy files to external services (e.g. Amazon S3), or deleting files from external services at the same time of Proffer creating/deleting images.
 I have created an example listener which is [available as an example](examples/UploadAndDeleteImageListener.md).
 

--- a/docs/examples/UploadAndDeleteImageListener.md
+++ b/docs/examples/UploadAndDeleteImageListener.md
@@ -20,7 +20,7 @@ class UploadAndDeleteImageListener implements EventListenerInterface {
     {
         return [
             'Proffer.afterCreateImage' => 'createImage',
-            'Proffer.beforeDeleteImage' => 'deleteImage',
+            'Proffer.beforeDeleteFolder' => 'deleteImage',
         ];
     }
 

--- a/docs/examples/UploadFilenameListener.md
+++ b/docs/examples/UploadFilenameListener.md
@@ -23,7 +23,7 @@ use Proffer\Lib\ProfferPath;
 
 class UploadFilenameListener implements EventListenerInterface
 {
-    public function implementedEvents()
+    public function implementedEvents(): array
     {
         return [
             'Proffer.afterPath' => 'change',
@@ -40,7 +40,7 @@ class UploadFilenameListener implements EventListenerInterface
     public function change(Event $event, ProfferPath $path)
     {
         // Detect and select the right file extension
-        switch ($event->subject()->get('image')['type']) {
+        switch ($event->getSubject()->get('image')['type']) {
             default:
             case "image/jpeg":
                 $ext = '.jpg';
@@ -54,20 +54,20 @@ class UploadFilenameListener implements EventListenerInterface
         }
 
         // Create a new filename using the id and the name of the entity
-        $newFilename = $event->subject()->get('id') . '_' . Inflector::slug($event->subject()->get('name')) . $ext;
+        $newFilename = $event->getSubject()->get('id') . '_' . Inflector::slug($event->getSubject()->get('name')) . $ext;
 
         // This would set the containing upload folder to `webroot/files/user_profile_pictures/<field>/<seed>/<file>` 
         // for every file uploaded through the table this listener was attached to.
         $path->setTable('user_profile_pictures'); 
 
         // If a seed is set in the data already, we'll use that rather than make a new one each time we upload
-        if (empty($event->subject()->get('image_dir'))) {
+        if (empty($event->getSubject()->get('image_dir'))) {
             $path->setSeed(date('Y-m-d-His'));
         }
 
         // Change the filename in both the path to be saved, and in the entity data for saving to the db
         $path->setFilename($newFilename);
-        $event->subject('image')['name'] = $newFilename;
+        $event->getSubject('image')['name'] = $newFilename;
 
         // Must return the modified path instance, so that things are saved in the right place
         return $path;

--- a/src/Lib/ImageTransform.php
+++ b/src/Lib/ImageTransform.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * ImageTransform class
  * This class deals with creating thumbnails for image uploads using the a library
@@ -79,7 +81,8 @@ class ImageTransform implements ImageTransformInterface
     public function makeThumbnail($prefix, array $config)
     {
         $defaultConfig = [
-            'jpeg_quality' => 100
+            'jpeg_quality' => 100,
+            'upsize' => true,
         ];
         $config = array_merge($defaultConfig, $config);
 
@@ -99,7 +102,7 @@ class ImageTransform implements ImageTransformInterface
         } elseif (!empty($config['custom'])) {
             $image = $this->thumbnailCustom($image, $config['custom'], $config['params']);
         } else {
-            $image = $this->thumbnailResize($image, $width, $height);
+            $image = $this->thumbnailResize($image, $width, $height, $config['upsize']);
         }
 
         unset($config['crop'], $config['w'], $config['h'], $config['custom'], $config['params'], $config['orientate']);
@@ -149,14 +152,22 @@ class ImageTransform implements ImageTransformInterface
      * @param \Intervention\Image\Image $image Image instance
      * @param int $width Desired width in pixels
      * @param int $height Desired height in pixels
+     * @param boolean $upsize if false the image will not be upsized
      *
      * @return \Intervention\Image\Image
      */
-    protected function thumbnailResize(Image $image, $width, $height)
+    protected function thumbnailResize(Image $image, $width, $height, $upsize)
     {
+        if ($upsize) {
+            return $image->resize($width, $height, function ($constraint) {
+                $constraint->aspectRatio();
+            });
+        } else {
         return $image->resize($width, $height, function ($constraint) {
             $constraint->aspectRatio();
+                $constraint->upsize();
         });
+    }
     }
 
     /**


### PR DESCRIPTION
Hi David

A couple of tweaks to your plugin, if you like.

1) Added an 'upsize' option for resizing to prevent stretching of images if they are smaller than specified width/height. This is backwards compatible.
2) Added examples for above
3) Corrected documentation beforeDeleteFolder event was misnamed
4) Updated Intervention API links

I've targeted cake4 branch only because that's my working copy, but these could apply to the cake3 version to.

Cheers
Brad