### PR TITLE
Make Exception when field is not set optional

### DIFF
--- a/src/Model/Behavior/ProfferBehavior.php
+++ b/src/Model/Behavior/ProfferBehavior.php
@@ -95,7 +95,9 @@ class ProfferBehavior extends Behavior
                 if ($entity->get($field)->getError() === UPLOAD_ERR_OK) {
                     $this->process($field, $settings, $entity, $path);
                 } else {
-                    throw new \Exception("Cannot find anything to process for the field `$field`");
+                    if (empty($settings['skipEmpty'])) {
+                        throw new \Exception("Cannot find anything to process for the field `$field`");
+                    }
                 }
             }
         }

--- a/tests/TestCase/Model/Behavior/ProfferBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/ProfferBehaviorTest.php
@@ -292,6 +292,48 @@ class ProfferBehaviorTest extends TestCase
     }
 
     /**
+     * A bit of a unit and integration test as it will still dispatch the events to the listener
+     *
+     * @dataProvider validFileProvider
+     *
+     * @param array $entityData
+     * @param array $expected
+     * @throws \Exception
+     */
+    public function testBeforeSaveWithoutValidFile(array $expected)
+    {
+        $entityData = [
+            'photo' => new UploadedFile(FIXTURE . 'image_640x480.jpg', 33000, UPLOAD_ERR_NO_FILE, 'image_640x480.jpg'),
+            'photo_dir' => 'proffer_test',
+        ];
+
+        $schema = $this->createMock(TableSchema::class);
+        $table = $this->createMock(Table::class);
+        $eventManager = $this->createMock(EventManager::class);
+        $table->method('getAlias')
+              ->willReturn('ProfferTest');
+        $table->method('getSchema')
+              ->willReturn($schema);
+        $table->method('getEventManager')
+              ->willReturn($eventManager);
+
+        $entity = new Entity($entityData);
+        /** @var ProfferPath $path */
+        $path = $this->_getProfferPathMock($table, $entity);
+
+        $proffer = new ProfferBehavior($table, $this->config);
+
+        $this->expectException(\Exception::class);
+
+        $proffer->beforeSave(
+            $this->createMock(Event::class),
+            $entity,
+            new ArrayObject(),
+            $path
+        );
+    }
+
+    /**
      * Test afterDelete
      */
     public function testAfterDelete()


### PR DESCRIPTION
I've made the Exception that is thrown when a field is empty in beforeSave optional. You can set the skipEmpty option to enable this.

The problem is that when I update anonther field (like name for example) in my entity the Proffer behavior is called and an exception is thrown. 